### PR TITLE
Fix empty extra vars / product list when using the new automatic text email option

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -945,7 +945,7 @@ abstract class PaymentModuleCore extends Module
     protected function getEmailTemplateContent($template_name, $mail_type, $var)
     {
         $email_configuration = Configuration::get('PS_MAIL_TYPE');
-        if ($email_configuration != $mail_type && $email_configuration != Mail::TYPE_BOTH) {
+        if ($email_configuration != $mail_type && ($email_configuration != Mail::TYPE_BOTH && $email_configuration != Mail::TYPE_BOTH_AUTOMATIC_TEXT)) {
             return '';
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 9.0.x
| Description?      | See Issue https://github.com/PrestaShop/PrestaShop/issues/40422
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Explained in the related issue
| Fixed issue or discussion?     | Fixes #40422
| Sponsor company   | Giuseppe Tripiciano
